### PR TITLE
Add Optional type

### DIFF
--- a/core/optional.go
+++ b/core/optional.go
@@ -32,5 +32,5 @@ func (o *Optional[T]) MarshalJSON() ([]byte, error) {
 	if o.Null {
 		return []byte("null"), nil
 	}
-	return json.Marshal(o.Value)
+	return json.Marshal(&o.Value)
 }

--- a/core/optional.go
+++ b/core/optional.go
@@ -1,0 +1,36 @@
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Optional is a wrapper used for all optional values sent to
+// the API, to distinguish zero values from null or omitted fields.
+//
+// To instantiate an Optional, use the helpers `O()` and `Null()`
+// helpers exported from the root package.
+type Optional[T any] struct {
+	Value T
+	Null  bool
+}
+
+func (o *Optional[T]) String() string {
+	if o == nil {
+		return ""
+	}
+	if s, ok := any(o.Value).(fmt.Stringer); ok {
+		return s.String()
+	}
+	return fmt.Sprintf("%#v", o.Value)
+}
+
+func (o *Optional[T]) MarshalJSON() ([]byte, error) {
+	if o == nil {
+		return nil, nil
+	}
+	if o.Null {
+		return []byte("null"), nil
+	}
+	return json.Marshal(o.Value)
+}

--- a/core/optional_test.go
+++ b/core/optional_test.go
@@ -1,0 +1,77 @@
+package core
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type OptionalRequest struct {
+	Id     string            `json:"id"`
+	Filter *Optional[string] `json:"filter,omitempty"`
+}
+
+func TestOptional(t *testing.T) {
+	tests := []struct {
+		desc         string
+		giveOptional *Optional[any]
+		wantBytes    []byte
+	}{
+		{
+			desc: "primitive",
+			giveOptional: &Optional[any]{
+				Value: "foo",
+			},
+			wantBytes: []byte(`"foo"`),
+		},
+		{
+			desc: "null primitive",
+			giveOptional: &Optional[any]{
+				Null: true,
+			},
+			wantBytes: []byte("null"),
+		},
+		{
+			desc: "object",
+			giveOptional: &Optional[any]{
+				Value: &OptionalRequest{
+					Id: "xyz",
+					Filter: &Optional[string]{
+						Value: "foo",
+					},
+				},
+			},
+			wantBytes: []byte(`{"id":"xyz","filter":"foo"}`),
+		},
+		{
+			desc: "null object",
+			giveOptional: &Optional[any]{
+				Value: &OptionalRequest{
+					Id: "xyz",
+					Filter: &Optional[string]{
+						Null: true,
+					},
+				},
+			},
+			wantBytes: []byte(`{"id":"xyz","filter":null}`),
+		},
+		{
+			desc: "empty object",
+			giveOptional: &Optional[any]{
+				Value: &OptionalRequest{
+					Id: "xyz",
+				},
+			},
+			wantBytes: []byte(`{"id":"xyz"}`),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			bytes, err := json.Marshal(test.giveOptional)
+			require.NoError(t, err)
+			assert.Equal(t, test.wantBytes, bytes)
+		})
+	}
+}

--- a/optional.go
+++ b/optional.go
@@ -2,8 +2,8 @@ package api
 
 import core "github.com/hookdeck/hookdeck-go-sdk/core"
 
-// O initializes an optional field.
-func O[T any](value T) *core.Optional[T] {
+// Optional initializes an optional field.
+func Optional[T any](value T) *core.Optional[T] {
 	return &core.Optional[T]{
 		Value: value,
 	}

--- a/optional.go
+++ b/optional.go
@@ -1,0 +1,18 @@
+package api
+
+import core "github.com/hookdeck/hookdeck-go-sdk/core"
+
+// O initializes an optional field.
+func O[T any](value T) *core.Optional[T] {
+	return &core.Optional[T]{
+		Value: value,
+	}
+}
+
+// Null initializes an optional field that will be sent as
+// an explicit null value.
+func Null[T any]() *core.Optional[T] {
+	return &core.Optional[T]{
+		Null: true,
+	}
+}

--- a/sources.go
+++ b/sources.go
@@ -40,8 +40,8 @@ type UpdateSourceRequest struct {
 	// Description for the source
 	Description        *core.Optional[string]                  `json:"description,omitempty"`
 	AllowedHttpMethods *core.Optional[SourceAllowedHttpMethod] `json:"allowed_http_methods,omitempty"`
-	CustomResponse     *core.Optional[*SourceCustomResponse]   `json:"custom_response,omitempty"`
-	Verification       *core.Optional[*VerificationConfig]     `json:"verification,omitempty"`
+	CustomResponse     *core.Optional[SourceCustomResponse]    `json:"custom_response,omitempty"`
+	Verification       *core.Optional[VerificationConfig]      `json:"verification,omitempty"`
 }
 
 type UpsertSourceRequest struct {

--- a/sources.go
+++ b/sources.go
@@ -4,6 +4,8 @@ package api
 
 import (
 	time "time"
+
+	core "github.com/hookdeck/hookdeck-go-sdk/core"
 )
 
 type CreateSourceRequest struct {
@@ -34,12 +36,12 @@ type GetSourcesRequest struct {
 
 type UpdateSourceRequest struct {
 	// A unique name for the source <span style="white-space: nowrap">`<= 155 characters`</span>
-	Name *string `json:"name,omitempty"`
+	Name *core.Optional[string] `json:"name,omitempty"`
 	// Description for the source
-	Description        *string                  `json:"description,omitempty"`
-	AllowedHttpMethods *SourceAllowedHttpMethod `json:"allowed_http_methods,omitempty"`
-	CustomResponse     *SourceCustomResponse    `json:"custom_response,omitempty"`
-	Verification       *VerificationConfig      `json:"verification,omitempty"`
+	Description        *core.Optional[string]                  `json:"description,omitempty"`
+	AllowedHttpMethods *core.Optional[SourceAllowedHttpMethod] `json:"allowed_http_methods,omitempty"`
+	CustomResponse     *core.Optional[*SourceCustomResponse]   `json:"custom_response,omitempty"`
+	Verification       *core.Optional[*VerificationConfig]     `json:"verification,omitempty"`
 }
 
 type UpsertSourceRequest struct {

--- a/sources/client_test.go
+++ b/sources/client_test.go
@@ -16,8 +16,8 @@ func TestClient(t *testing.T) {
 		context.TODO(),
 		"<SOURCE_ID>",
 		&hookdeckgosdk.UpdateSourceRequest{
-			Name:           hookdeckgosdk.O("name"),
-			CustomResponse: hookdeckgosdk.Null[*hookdeckgosdk.SourceCustomResponse](),
+			Name:           hookdeckgosdk.Optional("name"),
+			CustomResponse: hookdeckgosdk.Null[hookdeckgosdk.SourceCustomResponse](),
 		},
 	)
 	require.NoError(t, err)

--- a/sources/client_test.go
+++ b/sources/client_test.go
@@ -1,0 +1,25 @@
+package sources
+
+import (
+	context "context"
+	"testing"
+
+	hookdeckgosdk "github.com/hookdeck/hookdeck-go-sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient(t *testing.T) {
+	t.Skip("Temporarily included to show an example using optionals")
+	client := NewClient()
+	source, err := client.UpdateSource(
+		context.TODO(),
+		"<SOURCE_ID>",
+		&hookdeckgosdk.UpdateSourceRequest{
+			Name:           hookdeckgosdk.O("name"),
+			CustomResponse: hookdeckgosdk.Null[*hookdeckgosdk.SourceCustomResponse](),
+		},
+	)
+	require.NoError(t, err)
+	assert.NotEmpty(t, source)
+}


### PR DESCRIPTION
This adds a generic `Optional` type that is used for optional request parameters. With this, optional request parameters are clearly separated from their required counterparts, and users can interact with them like so:

```go
import (
  hookdeck "github.com/hookdeck/hookdeck-go-sdk"
  hookdeckclient "github.com/hookdeck/hookdeck-go-sdk/client"
)

client := hookdeckclient.NewClient()
source, err := client.Sources().UpdateSource(
  context.TODO(),
  "<SOURCE_ID>",
  &hookdeck.UpdateSourceRequest{
    Name:           hookdeck.Optional("example"),
    CustomResponse: hookdeck.Null[hookdeckgosdk.SourceCustomResponse](),
  },
  // Serialized as {"name":"example","custom_response":null}
)
```

The `hookdeck.Optional` function is a convenience function for initializing a valid `core.Optional[T]` value for any type, whereas the `hookdeck.Null` function can be used to send explicit `null` values (shown above). Note that the `core.Optional[T]` type only applies to optional request parameters - you cannot send an explicit `null` value for any required parameter (as intended).

This PR only demonstrates the change on the `client.Sources.UpdateSource` endpoint for now, but it will soon be part of `fern-go` so that it is automatically applied everywhere.