### PR TITLE
:herb: Add OptionalOrNull helper

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -2,3 +2,7 @@
 
 README.md
 LICENSE
+
+# Temporarily ignored for the OptionalOrNull helper.
+optional.go
+optional_test.go

--- a/optional.go
+++ b/optional.go
@@ -20,3 +20,12 @@ func Null[T any]() *core.Optional[T] {
 		Null: true,
 	}
 }
+
+// OptionalOrNull initializes an optional field, setting the value
+// to an explicit null if the value is nil.
+func OptionalOrNull[T any](value *T) *core.Optional[T] {
+	if value == nil {
+		return Null[T]()
+	}
+	return Optional(*value)
+}

--- a/optional_test.go
+++ b/optional_test.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"testing"
+
+	core "github.com/hookdeck/hookdeck-go-sdk/core"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOptionalOrNull(t *testing.T) {
+	t.Run("nil primitive", func(t *testing.T) {
+		var value *string
+		optional := OptionalOrNull(value)
+		assert.Equal(t, &core.Optional[string]{Null: true}, optional)
+	})
+
+	t.Run("zero primitive", func(t *testing.T) {
+		var zero int
+		optional := OptionalOrNull(&zero)
+		assert.Equal(t, &core.Optional[int]{Value: zero}, optional)
+	})
+
+	t.Run("non-zero primitive", func(t *testing.T) {
+		value := "test"
+		optional := OptionalOrNull(&value)
+		assert.Equal(t, &core.Optional[string]{Value: value}, optional)
+	})
+
+	t.Run("nil type", func(t *testing.T) {
+		type foo struct {
+			Name string
+		}
+		var zero *foo
+		optional := OptionalOrNull(zero)
+		assert.Equal(t, &core.Optional[foo]{Null: true}, optional)
+	})
+
+	t.Run("zero type", func(t *testing.T) {
+		type foo struct {
+			Name string
+		}
+		zero := new(foo)
+		optional := OptionalOrNull(zero)
+		assert.Equal(t, &core.Optional[foo]{Value: *zero}, optional)
+	})
+
+	t.Run("non-zero type", func(t *testing.T) {
+		type foo struct {
+			Name string
+		}
+		value := &foo{Name: "test"}
+		optional := OptionalOrNull(value)
+		assert.Equal(t, &core.Optional[foo]{Value: *value}, optional)
+	})
+}


### PR DESCRIPTION
This adds a simple `OptionalOrNull` helper that can be used to send an explicit `null` whenever the given value is `nil`. A variety of unit tests are included to demonstrate the use case.