### PR TITLE
Add OptionalOrNullFromPtr variant

### DIFF
--- a/optional.go
+++ b/optional.go
@@ -35,14 +35,14 @@ func OptionalOrNull[T any](value T) *core.Optional[T] {
 	return Optional(value)
 }
 
-// OptionalOrNullPtr initializes an optional field, setting the value
+// OptionalOrNullFromPtr initializes an optional field, setting the value
 // to an explicit null if the value is nil.
 //
 // This function avoids the cost of reflection and simply returns
 // a Optional[T] with the type pointed to by the given value. This
 // is  particularly useful for transforming struct pointers into their
 // value-based equivalent (i.e. *T -> Optional[T]).
-func OptionalOrNullPtr[T any](value *T) *core.Optional[T] {
+func OptionalOrNullFromPtr[T any](value *T) *core.Optional[T] {
 	if value == nil {
 		return Null[T]()
 	}

--- a/optional.go
+++ b/optional.go
@@ -3,6 +3,8 @@
 package api
 
 import (
+	"reflect"
+
 	core "github.com/hookdeck/hookdeck-go-sdk/core"
 )
 
@@ -23,7 +25,24 @@ func Null[T any]() *core.Optional[T] {
 
 // OptionalOrNull initializes an optional field, setting the value
 // to an explicit null if the value is nil.
-func OptionalOrNull[T any](value *T) *core.Optional[T] {
+func OptionalOrNull[T any](value T) *core.Optional[T] {
+	switch v := reflect.ValueOf(value); v.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		if v.IsNil() {
+			return Null[T]()
+		}
+	}
+	return Optional(value)
+}
+
+// OptionalOrNullPtr initializes an optional field, setting the value
+// to an explicit null if the value is nil.
+//
+// This function avoids the cost of reflection and simply returns
+// a Optional[T] with the type pointed to by the given value. This
+// is  particularly useful for transforming struct pointers into their
+// value-based equivalent (i.e. *T -> Optional[T]).
+func OptionalOrNullPtr[T any](value *T) *core.Optional[T] {
 	if value == nil {
 		return Null[T]()
 	}

--- a/optional_test.go
+++ b/optional_test.go
@@ -82,22 +82,22 @@ func TestOptionalOrNull(t *testing.T) {
 	})
 }
 
-func TestOptionalOrNullPtr(t *testing.T) {
+func TestOptionalOrNullFromPtr(t *testing.T) {
 	t.Run("nil primitive", func(t *testing.T) {
 		var value *string
-		optional := OptionalOrNullPtr(value)
+		optional := OptionalOrNullFromPtr(value)
 		assert.Equal(t, &core.Optional[string]{Null: true}, optional)
 	})
 
 	t.Run("zero primitive", func(t *testing.T) {
 		var zero int
-		optional := OptionalOrNullPtr(&zero)
+		optional := OptionalOrNullFromPtr(&zero)
 		assert.Equal(t, &core.Optional[int]{Value: zero}, optional)
 	})
 
 	t.Run("non-zero primitive", func(t *testing.T) {
 		value := "test"
-		optional := OptionalOrNullPtr(&value)
+		optional := OptionalOrNullFromPtr(&value)
 		assert.Equal(t, &core.Optional[string]{Value: value}, optional)
 	})
 
@@ -106,7 +106,7 @@ func TestOptionalOrNullPtr(t *testing.T) {
 			Name string
 		}
 		var zero *foo
-		optional := OptionalOrNullPtr(zero)
+		optional := OptionalOrNullFromPtr(zero)
 		assert.Equal(t, &core.Optional[foo]{Null: true}, optional)
 	})
 
@@ -115,7 +115,7 @@ func TestOptionalOrNullPtr(t *testing.T) {
 			Name string
 		}
 		zero := new(foo)
-		optional := OptionalOrNullPtr(zero)
+		optional := OptionalOrNullFromPtr(zero)
 		assert.Equal(t, &core.Optional[foo]{Value: *zero}, optional)
 	})
 
@@ -124,7 +124,7 @@ func TestOptionalOrNullPtr(t *testing.T) {
 			Name string
 		}
 		value := &foo{Name: "test"}
-		optional := OptionalOrNullPtr(value)
+		optional := OptionalOrNullFromPtr(value)
 		assert.Equal(t, &core.Optional[foo]{Value: *value}, optional)
 	})
 }

--- a/optional_test.go
+++ b/optional_test.go
@@ -8,21 +8,96 @@ import (
 )
 
 func TestOptionalOrNull(t *testing.T) {
+	t.Run("nil map", func(t *testing.T) {
+		var value map[string]string
+		optional := OptionalOrNull(value)
+		assert.Equal(t, &core.Optional[map[string]string]{Null: true}, optional)
+	})
+
+	t.Run("zero map", func(t *testing.T) {
+		value := make(map[string]string)
+		optional := OptionalOrNull(value)
+		assert.Equal(t, &core.Optional[map[string]string]{Value: value}, optional)
+	})
+
+	t.Run("non-zero map", func(t *testing.T) {
+		value := map[string]string{
+			"foo": "bar",
+		}
+		optional := OptionalOrNull(value)
+		assert.Equal(t, &core.Optional[map[string]string]{Value: value}, optional)
+	})
+
+	t.Run("nil slice", func(t *testing.T) {
+		var value []string
+		optional := OptionalOrNull(value)
+		assert.Equal(t, &core.Optional[[]string]{Null: true}, optional)
+	})
+
+	t.Run("zero slice", func(t *testing.T) {
+		value := make([]string, 0, 0)
+		optional := OptionalOrNull(value)
+		assert.Equal(t, &core.Optional[[]string]{Value: value}, optional)
+	})
+
+	t.Run("non-zero slice", func(t *testing.T) {
+		value := []string{
+			"foo",
+			"bar",
+		}
+		optional := OptionalOrNull(value)
+		assert.Equal(t, &core.Optional[[]string]{Value: value}, optional)
+	})
+
+	t.Run("zero type", func(t *testing.T) {
+		type foo struct {
+			Name string
+		}
+		zero := foo{}
+		optional := OptionalOrNull(zero)
+		assert.Equal(t, &core.Optional[foo]{Value: zero}, optional)
+	})
+
+	t.Run("non-zero type", func(t *testing.T) {
+		type foo struct {
+			Name string
+		}
+		value := foo{Name: "test"}
+		optional := OptionalOrNull(value)
+		assert.Equal(t, &core.Optional[foo]{Value: value}, optional)
+	})
+
+	t.Run("zero interface", func(t *testing.T) {
+		var s string
+		var iface any = s
+		optional := OptionalOrNull(iface)
+		assert.Equal(t, &core.Optional[any]{Value: iface}, optional)
+	})
+
+	t.Run("non-zero interface", func(t *testing.T) {
+		s := "foo"
+		var iface any = s
+		optional := OptionalOrNull(iface)
+		assert.Equal(t, &core.Optional[any]{Value: iface}, optional)
+	})
+}
+
+func TestOptionalOrNullPtr(t *testing.T) {
 	t.Run("nil primitive", func(t *testing.T) {
 		var value *string
-		optional := OptionalOrNull(value)
+		optional := OptionalOrNullPtr(value)
 		assert.Equal(t, &core.Optional[string]{Null: true}, optional)
 	})
 
 	t.Run("zero primitive", func(t *testing.T) {
 		var zero int
-		optional := OptionalOrNull(&zero)
+		optional := OptionalOrNullPtr(&zero)
 		assert.Equal(t, &core.Optional[int]{Value: zero}, optional)
 	})
 
 	t.Run("non-zero primitive", func(t *testing.T) {
 		value := "test"
-		optional := OptionalOrNull(&value)
+		optional := OptionalOrNullPtr(&value)
 		assert.Equal(t, &core.Optional[string]{Value: value}, optional)
 	})
 
@@ -31,7 +106,7 @@ func TestOptionalOrNull(t *testing.T) {
 			Name string
 		}
 		var zero *foo
-		optional := OptionalOrNull(zero)
+		optional := OptionalOrNullPtr(zero)
 		assert.Equal(t, &core.Optional[foo]{Null: true}, optional)
 	})
 
@@ -40,7 +115,7 @@ func TestOptionalOrNull(t *testing.T) {
 			Name string
 		}
 		zero := new(foo)
-		optional := OptionalOrNull(zero)
+		optional := OptionalOrNullPtr(zero)
 		assert.Equal(t, &core.Optional[foo]{Value: *zero}, optional)
 	})
 
@@ -49,7 +124,7 @@ func TestOptionalOrNull(t *testing.T) {
 			Name string
 		}
 		value := &foo{Name: "test"}
-		optional := OptionalOrNull(value)
+		optional := OptionalOrNullPtr(value)
 		assert.Equal(t, &core.Optional[foo]{Value: *value}, optional)
 	})
 }


### PR DESCRIPTION
In preparation for the `Optional[T]` changes ([link](https://github.com/hookdeck/hookdeck-api-schema/pull/17)) to include Fern's built-in types (e.g. slices, maps, etc), this adds another `OptionalOrNullFromPtr` variant that can be used to transform pointer types (i.e. `*T`) into their `Optional[T]` equivalent.

Note that `OptionalOrNullFromPtr` uses the same behavior that `OptionalOrNull` previously used, but now that we want this to handle slices and maps, we want to preserve the type provided to us (i.e. `[]string` -> `Optional[[]string]`).

A couple examples constructing requests for the API are shown below:

```go
// All of the configured fields preserve the type (i.e. T -> T).
transformUpdateRequest := &TransformUpdateRequest{
  Name: OptionalOrNull(value.Name),
  Code: OptionalOrNull(value.Code),
  Env:  OptionalOrNull(value.Env),
}
```

```go
// We use `OptionalOrNullFromPtr` when we want to transform *T -> T.
issueTriggerCreateRequest := &IssueTriggerCreateRequest{
  Configs:  OptionalOrNullFromPtr(value.Configs),
  Channels: OptionalOrNullFromPtr(value.Channels),
  Name:     OptionalOrNull(value.Name),
}
```

We'll need to evaluate how this API feels in practice - these helpers are still manually maintained in this repository (hence the `.fernignore` entries).